### PR TITLE
chore(action): sets Eficode as the author of this action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,5 @@
 name: 'Resolve pull request refs'
+author: 'Eficode'
 description: 'outputs base_ref and head_ref for a PR comment (issue_comment event)'
 inputs:
   token:


### PR DESCRIPTION
Maybe this solves the issue that we cannot publish our action 🤷 